### PR TITLE
chore(autz_server): add and set require_pushed_authorization_requests to true to well-known endpoint

### DIFF
--- a/public/authz_server/.well-known/oauth-authorization-server
+++ b/public/authz_server/.well-known/oauth-authorization-server
@@ -4,6 +4,7 @@
 	"token_endpoint": "{{ as_url }}/token",
 	"introspection_endpoint": "{{ as_url }}/introspection",
 	"issuer": "{{ as_url }}",
+	"require_pushed_authorization_requests": true,
 	"jwks": {
 		"keys": [
 			{


### PR DESCRIPTION
This indicates that authorization flows must start from the Pushed Authorization Requests (PAR) endpoint
