### PR TITLE
fix: set token_endpoint_auth_methods_supported to none

### DIFF
--- a/public/authz_server/.well-known/oauth-authorization-server
+++ b/public/authz_server/.well-known/oauth-authorization-server
@@ -42,7 +42,7 @@
 		"pairwise"
 	],
 	"token_endpoint_auth_methods_supported": [
-		"attest_jwt_client_auth"
+		"none"
 	],
 	"token_endpoint_auth_signing_alg_values_supported": [
 		"ES256"


### PR DESCRIPTION
this is the value to be used when there are public clients, i.e. wallets
